### PR TITLE
UI 细节调整

### DIFF
--- a/style.css
+++ b/style.css
@@ -36,10 +36,30 @@
 	border-radius: 6px;
 	padding: 6px;
 	height: auto;
+	border-style: unset;
 }
-
+.dictItemHead-Menus_Btn svg {
+    fill: #2c2b2b17;
+}
+.dictItemHead-Title {
+    font-weight: bold;
+}
+.dictItemHead-FoldArrow {
+    padding: 5px;
+}
+.dictItemHead-Loader>div {
+    width: 4px;
+    height: 4px;
+    margin: 1px;
+    background: #99c99d;
+    border-radius: 100%;
+}
+.menuBar-Btn_Icon, .menuBar-Btn_Icon-fav, .menuBar-Btn_Icon-history {
+    width: 70%;
+    height: 70%;
+}
 .dictPanel-Root {
-	box-shadow: rgba(0, 0, 0, 0.2) 0 7px 21px 2px;
+    box-shadow: rgba(0, 0, 0, 0.2) 0 7px 21px 2px;
 }
 .isAnimate .menuBar-Btn, .isAnimate .menuBar-Btn-dir {
     border-radius: 6px;


### PR DESCRIPTION
### 调整条目：
1. 隐藏每条词典的外虚线边框
2. 词典名称文字加粗显示
3. 词典设置按钮颜色变浅、透明度增加（几乎隐藏）
4. 词典名称文字于设置按钮间距调整
5. 词典翻译数据未加载完成时图标调整 （更加小巧更加美观）
6. 主栏图标调整为原大小的 70% （更加美观）

### 最终效果图：

[![bFU9KJ.png](https://s4.ax1x.com/2022/02/24/bFU9KJ.png)](https://imgtu.com/i/bFU9KJ)
